### PR TITLE
Add docker build and push yml file to add to CI pipeline

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types:
       - closed
+    branches:
+      - main
 
 jobs:
   docker:
@@ -22,5 +24,6 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          context: .
           push: true
           tags: tyriol/pup-timers:latest

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,26 @@
+name: Docker Build and Push
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  docker:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: tyriol/pup-timers:latest


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate Docker image builds and pushes when a pull request is merged. 

### CI/CD Enhancements:
* [`.github/workflows/docker-build-push.yml`](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10R1-R26): Added a workflow named "Docker Build and Push" that triggers on pull request closures, specifically when the pull request is merged. It logs in to Docker Hub, sets up Docker Buildx, and builds and pushes the Docker image with the tag `tyriol/pup-timers:latest`.