### PR TITLE
Add code checkout step to docker job

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for Docker image building and pushing. The most notable change adds a step to check out the repository code before proceeding with the workflow.

Workflow updates:

* [`.github/workflows/docker-build-push.yml`](diffhunk://#diff-b7dce24085c1061be7542e1f68edac2c9002799454a47708546d1e7e6fbf2a10R15-R17): Added a `Checkout code` step using the `actions/checkout@v3` action to ensure the repository code is available for subsequent steps.