### PR TITLE
Fixed timers to work if not visible

### DIFF
--- a/src/components/Timers/Timer/Timer.test.tsx
+++ b/src/components/Timers/Timer/Timer.test.tsx
@@ -8,13 +8,12 @@ import type { Timer } from "../../../types/types";
 vi.mock("../../../lib/timers", () => ({
   formatTime: (secs: number) => ({
     displayDays: secs >= 86400 ? `${Math.floor(secs / 86400)}d` : "",
-    displayTime: new Date(secs * 1000).toISOString().substring(11, 19),
+    displayTime: new Date(Math.max(0, secs) * 1000)
+      .toISOString()
+      .substring(11, 19),
   }),
-  calculateElapsedTime: (
-    currentTime: number,
-    elapsed: number,
-    updatedAt: number,
-  ) => Math.floor((currentTime - updatedAt + elapsed * 1000) / 1000),
+  calculateElapsedTime: (currentTime: number, startTime: number) =>
+    Math.max(Math.floor((currentTime - startTime) / 1000)),
 }));
 
 const mockUpdateTimer = vi.fn(() => Promise.resolve());
@@ -76,11 +75,11 @@ describe("Stopwatch", () => {
       ...baseTimer,
       isRunning: true,
       elapsed: 15,
-      updatedAt: currentTime - 1000000,
+      startTime: currentTime - 1000000,
     });
-    expect(screen.getByText("00:16:55")).toBeInTheDocument();
+    expect(screen.getByText("00:16:40")).toBeInTheDocument();
     expect(mockUpdateTimer).toHaveBeenCalledWith(1, {
-      elapsed: 1015,
+      elapsed: 1000,
       updatedAt: currentTime,
     });
   });
@@ -210,11 +209,11 @@ describe("Countdown", () => {
       ...baseTimer,
       isRunning: true,
       elapsed: 5,
-      updatedAt: currentTime - 12000,
+      startTime: currentTime - 8000,
     });
-    expect(screen.getByText("00:00:13")).toBeInTheDocument();
+    expect(screen.getByText("00:00:22")).toBeInTheDocument();
     expect(mockUpdateTimer).toHaveBeenCalledWith(1, {
-      elapsed: 17,
+      elapsed: 8,
       updatedAt: currentTime,
     });
   });
@@ -225,7 +224,7 @@ describe("Countdown", () => {
       ...baseTimer,
       isRunning: true,
       elapsed: 5,
-      updatedAt: currentTime - 100000,
+      startTime: currentTime - 100000,
     });
     expect(screen.getByText("00:00:00")).toBeInTheDocument();
     expect(

--- a/src/components/Timers/Timer/Timer.test.tsx
+++ b/src/components/Timers/Timer/Timer.test.tsx
@@ -13,7 +13,7 @@ vi.mock("../../../lib/timers", () => ({
       .substring(11, 19),
   }),
   calculateElapsedTime: (currentTime: number, startTime: number) =>
-    Math.max(Math.floor((currentTime - startTime) / 1000)),
+    Math.max(0, Math.floor((currentTime - startTime) / 1000)),
 }));
 
 const mockUpdateTimer = vi.fn(() => Promise.resolve());

--- a/src/components/Timers/Timer/TimerDisplay.tsx
+++ b/src/components/Timers/Timer/TimerDisplay.tsx
@@ -64,7 +64,7 @@ const TimerDisplay = ({ timer }: TimerProps) => {
       }
     };
     void calculateAndSetTimeElapsedWhileOffline();
-  }, []);
+  }, [document.visibilityState]);
 
   useEffect(() => {
     if (isRunning) {

--- a/src/components/Timers/Timer/TimerDisplay.tsx
+++ b/src/components/Timers/Timer/TimerDisplay.tsx
@@ -30,40 +30,43 @@ const TimerDisplay = ({ timer }: TimerProps) => {
   const timerCardClass = `flex flex-col items-center justify-center gap-5 p-5 shadow-md ${getShadowColourClass(isRunning, elapsedSecs)} rounded-md bg-neutral-700/50`;
 
   useEffect(() => {
-    const calculateAndSetTimeElapsedWhileOffline = async () => {
-      if (isRunning && timer.updatedAt) {
-        const newElapsedSecs: number = calculateElapsedTime(
-          Date.now(),
-          elapsedSecs,
-          timer.updatedAt,
-        );
-        if (timer.type === "countdown" && timer.duration) {
-          const calculatedTimeRemaining = timer.duration - newElapsedSecs;
-          setElapsedSecs(
-            calculatedTimeRemaining < 0 ? timer.duration : newElapsedSecs,
+    if (document.visibilityState === "visible") {
+      const calculateAndSetTimeElapsedWhileOffline = async () => {
+        if (isRunning && timer.updatedAt) {
+          const newElapsedSecs: number = calculateElapsedTime(
+            Date.now(),
+            elapsedSecs,
+            timer.updatedAt,
           );
-          setTimeRemaining(
-            calculatedTimeRemaining < 0 ? 0 : calculatedTimeRemaining,
-          );
-          if (calculatedTimeRemaining <= 0) {
-            setIsRunning(false);
-            await updateTimer(timer.id, {
-              elapsed: timer.duration,
-              isRunning: false,
-              updatedAt: Date.now(),
-            });
-            return;
+          if (timer.type === "countdown" && timer.duration) {
+            const calculatedTimeRemaining = timer.duration - newElapsedSecs;
+            setElapsedSecs(
+              calculatedTimeRemaining < 0 ? timer.duration : newElapsedSecs,
+            );
+            setTimeRemaining(
+              calculatedTimeRemaining < 0 ? 0 : calculatedTimeRemaining,
+            );
+            if (calculatedTimeRemaining <= 0) {
+              setIsRunning(false);
+              await updateTimer(timer.id, {
+                elapsed: timer.duration,
+                isRunning: false,
+                updatedAt: Date.now(),
+              });
+              return;
+            }
+          } else {
+            setElapsedSecs(newElapsedSecs);
           }
-        } else {
-          setElapsedSecs(newElapsedSecs);
+          await updateTimer(timer.id, {
+            elapsed: newElapsedSecs,
+            updatedAt: Date.now(),
+          });
         }
-        await updateTimer(timer.id, {
-          elapsed: newElapsedSecs,
-          updatedAt: Date.now(),
-        });
-      }
-    };
-    void calculateAndSetTimeElapsedWhileOffline();
+      };
+
+      void calculateAndSetTimeElapsedWhileOffline();
+    }
   }, [document.visibilityState]);
 
   useEffect(() => {

--- a/src/components/Timers/Timer/TimerDisplay.tsx
+++ b/src/components/Timers/Timer/TimerDisplay.tsx
@@ -32,11 +32,10 @@ const TimerDisplay = ({ timer }: TimerProps) => {
   useEffect(() => {
     if (document.visibilityState === "visible") {
       const calculateAndSetTimeElapsedWhileOffline = async () => {
-        if (isRunning && timer.updatedAt) {
+        if (isRunning && timer.startTime) {
           const newElapsedSecs: number = calculateElapsedTime(
             Date.now(),
-            elapsedSecs,
-            timer.updatedAt,
+            timer.startTime,
           );
           if (timer.type === "countdown" && timer.duration) {
             const calculatedTimeRemaining = timer.duration - newElapsedSecs;

--- a/src/lib/timers.test.ts
+++ b/src/lib/timers.test.ts
@@ -37,7 +37,7 @@ describe("The timer utility functions", () => {
     expect(displayDays).toBe("10 days");
   });
 
-  it("calculates the current time elapsed", () => {
+  it("returns the time elapsed since start", () => {
     const currentTime = new Date("2025-08-21T10:00:00Z").getTime();
     const startTime = currentTime - 500000;
 

--- a/src/lib/timers.test.ts
+++ b/src/lib/timers.test.ts
@@ -39,10 +39,16 @@ describe("The timer utility functions", () => {
 
   it("calculates the current time elapsed", () => {
     const currentTime = new Date("2025-08-21T10:00:00Z").getTime();
-    const updatedAt = currentTime - 500000;
-    const elapsedSecs = 57;
+    const startTime = currentTime - 500000;
 
-    const elapsed = calculateElapsedTime(currentTime, elapsedSecs, updatedAt);
-    expect(elapsed).toBe(557);
+    const elapsed = calculateElapsedTime(currentTime, startTime);
+    expect(elapsed).toBe(500);
+  });
+
+  it("doesn't break if start time is after current time", () => {
+    const currentTime = new Date("2025-08-21T10:00:00Z").getTime();
+    const startTime = currentTime + 1;
+    const elapsed = calculateElapsedTime(currentTime, startTime);
+    expect(elapsed).toBe(0);
   });
 });

--- a/src/lib/timers.ts
+++ b/src/lib/timers.ts
@@ -28,8 +28,7 @@ export const formatTime = (secs: number) => {
 
 export const calculateElapsedTime = (
   currentTime: number,
-  elapsedSecs: number,
-  updateAt: number,
+  startTime: number,
 ) => {
-  return Math.floor((currentTime - updateAt + elapsedSecs * 1000) / 1000);
+  return Math.max(0, Math.floor((currentTime - startTime) / 1000));
 };


### PR DESCRIPTION
This pull request refactors the timer logic to consistently use `startTime` instead of `updatedAt` and `elapsed` for tracking elapsed time across the codebase. It updates both implementation and tests to simplify the calculation of elapsed time and improve reliability, especially when handling edge cases like negative elapsed time.

**Timer logic refactor:**

* Replaced the previous calculation of elapsed time using `updatedAt` and `elapsed` with a new approach that uses only `startTime` in `calculateElapsedTime` in `src/lib/timers.ts`, ensuring the result is never negative.
* Updated the mock implementation of `calculateElapsedTime` and `formatTime` in timer tests to match the new logic and prevent negative elapsed time.

**Test updates:**

* Modified timer and countdown test cases to use `startTime` instead of `updatedAt`, and adjusted expected elapsed values and displayed times accordingly in `src/components/Timers/Timer/Timer.test.tsx`. [[1]](diffhunk://#diff-6ba6af0b639ea250201ac7d971ee369349a2ae9b5a263845b96965c92aa97b01L79-R82) [[2]](diffhunk://#diff-6ba6af0b639ea250201ac7d971ee369349a2ae9b5a263845b96965c92aa97b01L213-R216) [[3]](diffhunk://#diff-6ba6af0b639ea250201ac7d971ee369349a2ae9b5a263845b96965c92aa97b01L228-R227)
* Added a new test to ensure `calculateElapsedTime` returns zero when `startTime` is after the current time in `src/lib/timers.test.ts`.

**Component logic update:**

* Updated the offline elapsed time calculation in `TimerDisplay` to use `startTime` instead of `updatedAt`, and to only run when the document is visible, improving accuracy and performance in `src/components/Timers/Timer/TimerDisplay.tsx`. [[1]](diffhunk://#diff-8b9c5d472fc7d176c69682bd5968902c08752cc8304b892a51d0c11a32d3f224R33-R38) [[2]](diffhunk://#diff-8b9c5d472fc7d176c69682bd5968902c08752cc8304b892a51d0c11a32d3f224R66-R69)